### PR TITLE
add gemmlowp package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@
 ??
 *binary*
 /.idea/
-CMakeLists.txt
 /bazel-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(gemmlowp VERSION 1.0.0)
+
+# Define root directory variable for subdirectories
+# that will work in case of add_subdirectory() use
+set(GEMMLOWP_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+add_library(gemmlowp INTERFACE)
+set(gemmlowp_inc_dir "${CMAKE_CURRENT_LIST_DIR}")
+target_include_directories(gemmlowp
+  INTERFACE
+  "$<BUILD_INTERFACE:${gemmlowp_inc_dir}>" # i.e., submodule use
+  )
+
+option(GEMMLOWP_BUILD_TESTS "Build test program" OFF)
+if(GEMMLOWP_BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(test)
+endif()
+
+### Install ###
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${version_config}" COMPATIBILITY SameMajorVersion
+  )
+
+# Note: use 'targets_export_name'
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in"
+  "${project_config}"
+  INSTALL_DESTINATION "${config_install_dir}"
+  )
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT "${targets_export_name}"
+  LIBRARY DESTINATION "lib"
+  ARCHIVE DESTINATION "lib"
+  RUNTIME DESTINATION "bin"
+  INCLUDES DESTINATION "${include_install_dir}"
+  )
+
+# install -m 755 -t $(INCLUDE_PREFIX)/public public/*.h
+# install -m 755 -t $(INCLUDE_PREFIX)/meta meta/*.h
+# install -m 755 -t $(INCLUDE_PREFIX)/internal internal/*.h
+# install -m 755 -t $(INCLUDE_PREFIX)/profiling profiling/*.h
+# install -m 755 -t $(INCLUDE_PREFIX)/fixedpoint fixedpoint/*.h
+
+foreach(dir public meta internal profiling fixedpoint)
+  message("DIR=${dir} ")
+  install(
+    DIRECTORY ${dir} # No trailing slash
+    DESTINATION "${include_install_dir}/"
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+    )
+endforeach()
+
+install(
+  FILES "${project_config}" "${version_config}"
+  DESTINATION "${config_install_dir}"
+  )
+
+install(
+  EXPORT "${targets_export_name}"
+  NAMESPACE "${namespace}"
+  DESTINATION "${config_install_dir}"
+  )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,12 +51,6 @@ install(
   INCLUDES DESTINATION "${include_install_dir}"
   )
 
-# install -m 755 -t $(INCLUDE_PREFIX)/public public/*.h
-# install -m 755 -t $(INCLUDE_PREFIX)/meta meta/*.h
-# install -m 755 -t $(INCLUDE_PREFIX)/internal internal/*.h
-# install -m 755 -t $(INCLUDE_PREFIX)/profiling profiling/*.h
-# install -m 755 -t $(INCLUDE_PREFIX)/fixedpoint fixedpoint/*.h
-
 foreach(dir public meta internal profiling fixedpoint)
   message("DIR=${dir} ")
   install(

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,22 @@
+# See README.txt
+#
+# The main test.cc file also contains tests for the legacy (deprecated) EigehBitIntGemm interface.
+# There is no conditional logic in the upstream code for these tests so we follow the README 
+# recommendation of simply adding eight
+
+# Add gemmlowp_ prefix as workaround for:
+# > The target name "test" is reserved or not valid for certain CMake features
+
+set(eight_bit_int_gemm_src ${GEMMLOWP_ROOT_DIR}/eight_bit_int_gemm/eight_bit_int_gemm.cc)
+add_executable(gemmlowp_test test.cc test_data.cc ${eight_bit_int_gemm_src})
+add_test(NAME gemmlowp_test COMMAND gemmlowp_test)
+
+set(test_src_files test_allocator.cc test_blocking_counter.cc test_fixedpoint.cc test_math_helpers.cc)
+foreach(test_src ${test_src_files})
+  get_filename_component(test_name ${test_src} NAME_WE)
+  set(test_srcs ${test_src} test_data.cc)
+  set(test_name "gemmlowp_${test_name}")
+  add_executable(${test_name} ${test_srcs} ${eight_bit_int_gemm_src})
+  target_link_libraries(${test_name} gemmlowp)
+  add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()


### PR DESCRIPTION
Export the gemmlowp header only interface per the README files.  Don’t export the “Old EightBitIntGemm legacy deprecated interface”.

* .gitignore : don't ignore CMakeLists.txt
* i've searched source files and see no version, will use 1.0.0
* GEMMLOWP_BUILD_TESTS to toggle tests
* ` find_package(gemmlowp CONFIG REQUIRED); target_link_libraries(app gemmlowp::gemmlowp)`
